### PR TITLE
KAN-157 Add ArgoCD Kind cluster

### DIFF
--- a/migraiton/terraform/.gitignore
+++ b/migraiton/terraform/.gitignore
@@ -1,0 +1,40 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# kind output
+*-config
+
+# lock file
+.terraform.lock.hcl

--- a/migraiton/terraform/as-is.tf
+++ b/migraiton/terraform/as-is.tf
@@ -1,0 +1,24 @@
+resource "kind_cluster" "as-is" {
+  name           = "as-is"
+  wait_for_ready = true
+  node_image     = "kindest/node:v1.28.7"
+
+  kind_config {
+    kind        = "Cluster"
+    api_version = "kind.x-k8s.io/v1alpha4"
+
+    node {
+      role = "control-plane"
+
+      # ArgoCD NodePort
+      extra_port_mappings {
+        container_port = 30950
+        host_port      = 30950
+      }
+    }
+
+    node {
+      role = "worker"
+    }
+  }
+}

--- a/migraiton/terraform/provider.tf
+++ b/migraiton/terraform/provider.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    kind = {
+      source  = "tehcyx/kind"
+      version = "0.4.0"
+    }
+  }
+}
+
+provider "kind" {}

--- a/migraiton/terraform/to-be.tf
+++ b/migraiton/terraform/to-be.tf
@@ -1,0 +1,24 @@
+resource "kind_cluster" "to-be" {
+  name           = "to-be"
+  wait_for_ready = true
+  node_image     = "kindest/node:v1.29.2"
+
+  kind_config {
+    kind        = "Cluster"
+    api_version = "kind.x-k8s.io/v1alpha4"
+
+    node {
+      role = "control-plane"
+
+      # ArgoCD NodePort
+      extra_port_mappings {
+        container_port = 30960
+        host_port      = 30960
+      }
+    }
+
+    node {
+      role = "worker"
+    }
+  }
+}


### PR DESCRIPTION
ArgoCD Migration테스트를 위해 AS-IS, TO-BE Kind cluster 생성 예제를 추가합니다.