### PR TITLE
KAN-160 Add kind clusters for attach ArgoCD

### DIFF
--- a/migraiton/terraform/README.md
+++ b/migraiton/terraform/README.md
@@ -10,6 +10,9 @@
 * terraform으로 ArgoCD migration 테스트 환경 구성
 * kubernetes는 kind cluster를 사용
 
+# 전제조건
+* kind 바이너리가 설치되어 있어야 함
+
 # 아키텍처
 
 ![](./imgs/arch.png)
@@ -27,8 +30,11 @@ terraform apply
 
 ```sh
 $ ls -l *-config
--rw-------  1 test  test  5600 May 12 00:21 as-is-config
--rw-------  1 test  test  5604 May 11 23:42 to-be-config
+-rw-------  1 testuser  testgroup  5600 May 12 00:21 as-is-config
+-rw-------  1 testuser  testgroup  5632 May 12 00:51 cluster-a-config
+-rw-------  1 testuser  testgroup  5632 May 12 00:51 cluster-b-config
+-rw-------  1 testuser  testgroup  5632 May 12 00:51 cluster-c-config
+-rw-------  1 testuser  testgroup  5604 May 11 23:42 to-be-config
 ```
 
 * kubectl 사용 방법
@@ -36,10 +42,14 @@ $ ls -l *-config
 ```sh
 # AS-IS kind cluster
 KUBECONFIG=as-is-config kubectl get nodes
-KUBECONFIG=as-is-config kubectl get pod -n argocd
 
 # TO-BE kind cluster
 KUBECONFIG=to-be-config kubectl get nodes
+
+# ArgoCD에 연결할 cluster목록
+KUBECONFIG=cluster-a-config kubectl get nodes
+KUBECONFIG=cluster-b-config kubectl get nodes
+KUBECONFIG=cluster-c-config kubectl get nodes
 ```
 
 # ArgoCD 설치 확인

--- a/migraiton/terraform/destinations.tf
+++ b/migraiton/terraform/destinations.tf
@@ -1,0 +1,44 @@
+resource "kind_cluster" "cluster_a" {
+  name           = "cluster-a"
+  wait_for_ready = true
+  node_image     = "kindest/node:v1.29.2"
+
+  kind_config {
+    kind        = "Cluster"
+    api_version = "kind.x-k8s.io/v1alpha4"
+
+    node {
+      role = "control-plane"
+    }
+  }
+}
+
+resource "kind_cluster" "cluster_b" {
+  name           = "cluster-b"
+  wait_for_ready = true
+  node_image     = "kindest/node:v1.29.2"
+
+  kind_config {
+    kind        = "Cluster"
+    api_version = "kind.x-k8s.io/v1alpha4"
+
+    node {
+      role = "control-plane"
+    }
+  }
+}
+
+resource "kind_cluster" "cluster_c" {
+  name           = "cluster-c"
+  wait_for_ready = true
+  node_image     = "kindest/node:v1.29.2"
+
+  kind_config {
+    kind        = "Cluster"
+    api_version = "kind.x-k8s.io/v1alpha4"
+
+    node {
+      role = "control-plane"
+    }
+  }
+}


### PR DESCRIPTION
ArgoCD 마이그레이션 테스트를 위해, ArgoCD에 등록할 kubernetes cluster 여러개를 생성하는 예제를 추가합니다.