### PR TITLE
KAN-160 Fix ArgoCD project generator

### DIFF
--- a/migraiton/argocd_clusters/Makefile
+++ b/migraiton/argocd_clusters/Makefile
@@ -1,0 +1,12 @@
+create-secrets:
+	@python create_kubernetes_secrets.py
+
+create-to-asis: create-secrets
+	@KUBECONFIG=../terraform/as-is-config kubectl apply -f kind-cluster-a-secrets.yaml
+	@KUBECONFIG=../terraform/as-is-config kubectl apply -f kind-cluster-b-secrets.yaml
+	@KUBECONFIG=../terraform/as-is-config kubectl apply -f kind-cluster-c-secrets.yaml
+
+create-to-tobe: create-secrets
+	@KUBECONFIG=../terraform/to-be-config kubectl apply -f kind-cluster-a-secrets.yaml
+	@KUBECONFIG=../terraform/to-be-config kubectl apply -f kind-cluster-b-secrets.yaml
+	@KUBECONFIG=../terraform/to-be-config kubectl apply -f kind-cluster-c-secrets.yaml

--- a/migraiton/argocd_clusters/template.yaml
+++ b/migraiton/argocd_clusters/template.yaml
@@ -8,7 +8,7 @@ metadata:
 type: Opaque
 stringData:
   name: "{{CLUSTER_NAME}}"
-  server: "https://{{CLUSTER_NAME}}"
+  server: "https://{{CLUSTER_NAME}}:6443"
   config: |
     {
       "tlsClientConfig": {


### PR DESCRIPTION
ArgoCD Migration예제에서 ArgoCD Project생성 스크립트 중,cluster주소가 잘못되어 수정합니다.