### PR TITLE
add ApplicationSet UI investigation and lab setup

### DIFF
--- a/applicationset_ui/AGENTS.md
+++ b/applicationset_ui/AGENTS.md
@@ -1,0 +1,16 @@
+# Problem of argocd application
+
+2026년 3월 기준으로 Argo CD web dashboard에서 왼쪽 메뉴에 applicationset을 보는게 가능할까? web_fetch tools를 사용하여 아래 참고자료를 보고 판단하고, 가능하다면 실습자료를 만드세요.
+
+- 참고자료
+  - https://www.linkedin.com/posts/argoproj_heads-up-argo-cd-users-applicationsets-activity-7422399925180862465-wORP?utm_source=share&utm_medium=member_desktop&rcm=ACoAAB3jNXwBQaX2ciprQbfJ2o33vJjPd_arJ5E
+  - https://docs.akuity.io/argocd/managing-instances/settings/extensions/applicationset-extension/
+
+## 실습환경
+
+- 로컬에서 kind cluster를 사용하여 쿠버네티스를 생성한다.
+- Argo CD는 helm chart를 사용한다.
+
+## agent skills
+
+- 문서작성은 akbun style skills를 사용한다.

--- a/applicationset_ui/README.md
+++ b/applicationset_ui/README.md
@@ -1,0 +1,60 @@
+# Argo CD ApplicationSet UI 조사
+
+## 요약
+
+- 2026년 3월 기준, 오픈소스 Argo CD v3.3.2에서는 **왼쪽 메뉴에 ApplicationSet 항목이 없음**
+- v3.3.0의 `appset ui support` 커밋은 내부 코드 레벨의 추상화 레이어일 뿐, UI 메뉴로 노출되지 않음
+- **ApplicationSet UI는 Akuity Platform의 상용 extension에서만 제공**
+
+## 목차
+
+- [배경](#배경)
+- [조사 결과](#조사-결과)
+- [결론](#결론)
+- [참고자료](#참고자료)
+
+## 배경
+
+Argo CD web dashboard에서 ApplicationSet을 왼쪽 메뉴에서 직접 확인할 수 있는지 조사했습니다.
+
+기존에는 ApplicationSet을 YAML로만 관리하고, UI에서는 생성된 Application만 볼 수 있었습니다. **ApplicationSet 자체를 UI에서 시각화하고 관리하는 기능은 오랫동안 커뮤니티에서 요청받아온 기능입니다.**
+
+## 조사 결과
+
+2026년 3월 기준, 오픈소스 Argo CD에서는 ApplicationSet을 UI로 관리할 수 없습니다. ApplicationSet UI가 필요한 경우 Akuity Platform을 사용해야 합니다.
+
+| 항목 | 오픈소스 Argo CD v3.3.x | Akuity Platform |
+| --- | --- | --- |
+| ApplicationSet UI 메뉴 | 없음 | 있음 (Extension 설치 필요) |
+| 비용 | 무료 | 상용 |
+
+## 조사 상세 내용
+
+### Argo Project 공식 발표 (2026년 1월)
+
+Argo Project는 2026년 1월 28일 LinkedIn에서 "ApplicationSets are coming to the Argo CD UI"를 발표했습니다. Peter Jiang이 개발을 주도하고 있으며, 초기 mock-up이 공개되었습니다.
+
+### Argo CD v3.3.2 실제 확인 (2026년 3월)
+
+Argo CD v3.3.2를 kind cluster에 설치하여 확인한 결과, **왼쪽 메뉴에 ApplicationSet 항목이 존재하지 않습니다.** 이 커밋은 향후 UI 기능을 위한 내부 코드 추상화 레이어일 뿐입니다. v3.3.0 릴리스에 다음 커밋이 포함되었지만, 실제 UI에 반영되지 않았습니다.
+
+```text
+feat(ui): implement abstraction layer for appset ui support (#24916) - @pjiang-dev
+```
+
+### Akuity Platform (상용)
+
+Akuity Platform에서는 ApplicationSet extension을 제공합니다.
+
+- Full CRUD Management (생성, 조회, 수정, 삭제)
+- Status Visualization (상태 시각화)
+- Live Previews (배포 전 미리보기)
+
+Settings > Extensions > ApplicationSet extension에서 설치할 수 있습니다. **오픈소스 Argo CD에서는 이 extension을 사용할 수 없습니다.**
+
+## 참고자료
+
+- <https://www.linkedin.com/posts/argoproj_heads-up-argo-cd-users-applicationsets-activity-7422399925180862465-wORP>
+- <https://docs.akuity.io/argocd/managing-instances/settings/extensions/applicationset-extension/>
+- <https://github.com/argoproj/argo-cd/releases/tag/v3.3.0>
+- <https://github.com/argoproj/argo-cd/pull/24916>

--- a/applicationset_ui/helm/values.yaml
+++ b/applicationset_ui/helm/values.yaml
@@ -1,0 +1,23 @@
+## Argo CD v3.3.2 (Helm Chart 9.4.7)
+## ApplicationSet UI 지원을 위한 values 설정
+
+global:
+  domain: ""
+
+## argocd-server를 NodePort로 노출 (kind cluster 사용)
+server:
+  service:
+    type: NodePort
+    nodePortHttps: 30950
+
+  ## insecure 모드 활성화 (TLS 없이 접속)
+  extraArgs:
+    - --insecure
+
+## ApplicationSet Controller 설정
+applicationSet:
+  enabled: true
+
+## Redis HA 비활성화 (로컬 환경)
+redis-ha:
+  enabled: false

--- a/applicationset_ui/manifests/sample-applicationset.yaml
+++ b/applicationset_ui/manifests/sample-applicationset.yaml
@@ -1,0 +1,30 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: sample-appset
+  namespace: argocd
+spec:
+  generators:
+    - list:
+        elements:
+          - cluster: in-cluster
+            url: https://kubernetes.default.svc
+            app: nginx
+  template:
+    metadata:
+      name: "{{app}}-{{cluster}}"
+      labels:
+        app.kubernetes.io/managed-by: applicationset
+    spec:
+      project: default
+      source:
+        repoURL: https://github.com/argoproj/argocd-example-apps.git
+        targetRevision: HEAD
+        path: guestbook
+      destination:
+        server: "{{url}}"
+        namespace: default
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true

--- a/install_argocd_with_helm/README.md
+++ b/install_argocd_with_helm/README.md
@@ -1,16 +1,17 @@
 # 개요
-* helm 으로 argocd 설치
 
-# 설치방법
+helm 으로 argocd 설치하는 방법을 다룹니다.
 
-* helm chart 추가
+## 설치방법
+
+- helm chart 추가
 
 ```bash
 helm repo add argo https://argoproj.github.io/argo-helm
 helm repo update
 ```
 
-* helm chart 릴리즈
+- helm chart 릴리즈
 
 ```bash
 helm upgrade --install argocd argo/argo-cd \
@@ -18,19 +19,42 @@ helm upgrade --install argocd argo/argo-cd \
   -f my-values.yaml
 ```
 
-# argocd-server 접속 방법
-* 웹 브라우저에서 https://{YOUR_DOMAIN} 접속
+## argocd-server 접속 방법
 
-# admin 비밀번호 조회
+### 방법1: NodePort
+
+argocd-server를 NodePort로 설정한 경우 브라우저에서 접속합니다.
+
+```bash
+http://localhost:{NodePort} # 예시: 30950 http://localhost:30950
+```
+
+### 방법2: kubectl port-forward
+
+port-forward로 argocd-server에 접속합니다.
+
+```bash
+kubectl port-forward svc/argocd-server -n argocd 8080:443
+```
+
+브라우저에서 접속합니다.
+
+```bash
+http://localhost:8080
+```
+
+## admin 비밀번호 조회
+
 ```bash
 kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d; echo
 ```
 
-# 삭제방법
+## 삭제방법
 
 ```bash
 helm uninstall -n argocd argocd
 ```
 
-# EKS에 ArgoCD 설치
-* [메뉴얼 바로가기](./eks/)
+## EKS에 ArgoCD 설치
+
+- [메뉴얼 바로가기](./eks/)

--- a/kind-cluster/config.yaml
+++ b/kind-cluster/config.yaml
@@ -3,9 +3,10 @@ apiVersion: kind.x-k8s.io/v1alpha4
 name: argocd-practice
 nodes:
 - role: control-plane
-  image: kindest/node:v1.28.0
+  image: kindest/node:v1.35.0
+  # NodePort 서비스를 localhost에서 접근하기 위한 포트 매핑
   extraPortMappings:
-  - containerPort: 30950
+  - containerPort: 30950 # argocd-server (https)
     hostPort: 30950
   - containerPort: 30951
     hostPort: 30951
@@ -16,4 +17,4 @@ nodes:
   - containerPort: 30962
     hostPort: 30962
 - role: worker
-  image: kindest/node:v1.28.0
+  image: kindest/node:v1.35.0


### PR DESCRIPTION
## 작업 내용
오픈소스 ArgoCD v3.3.x에서 ApplicationSet UI를 지원하는지 조사하고, 검증을 위한 실습 환경을 구성했습니다.

## 주요 변경 사항
- ArgoCD ApplicationSet UI 지원 여부 조사 결과 정리 (오픈소스 미지원, Akuity Platform 상용 기능)
- kind cluster 기반 실습 환경 구성 (kubernetes v1.35.0 업그레이드, NodePort 포트매핑)
- ArgoCD v3.3.2 helm values 추가 (NodePort, insecure 모드, ApplicationSet Controller 활성화)
- 샘플 ApplicationSet manifest 추가 (list generator 방식)
- ArgoCD 설치 문서에 NodePort/port-forward 접속 방법 추가